### PR TITLE
Provide memory value as int for libvirt provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure(2) do |config|
    end
 
    config.vm.provider "libvirt" do |lv|
-      lv.memory = #{VM_MEM}
+      lv.memory = "#{VM_MEM}".to_i
       lv.cpus = 2
    end
 


### PR DESCRIPTION
The libvirt provider expects an int value for the memory domain option. Ruby has no implicit conversion of String into Integer and the configured memory value is always set to "2M".