### PR TITLE
Clarify access for the admin user

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -30,7 +30,7 @@ It will add a:
 
 * Router
 * Registry
-* Admin user as cluster-admin
+* A user called `admin` as the cluster-admin
 * Origin Centos ImageStreams and templates
 
 === SCRIPTS
@@ -124,7 +124,7 @@ vagrant up --provider virtualbox
 ----
 
 === USERS
-Any user with any password will login as a regular user. If you want to access as an admin user, you need to use *cluster-admin*
+Any user with any password will login as a regular user. If you want to access as an admin user, you need to use *admin* as the username.
 
 === RUNNING IMAGES
 This VM is meant for development purposes, so it's allowed to run any image as anyuid, allowing to run images made to run as root.


### PR DESCRIPTION
When trying this out I initially tried logging in as the cluster-admin
user, rather than just using admin. I thing this change should hopefully
help anyone else running into the same issue.

The user is called admin as per
https://github.com/garethr/vagrant-origin/blob/master/scripts/origin-setup.sh#L220