### PR TITLE
Fix #35: Install latest version of docker on centos.

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -68,10 +68,12 @@ For the installation (This configuration will be in the VM or in *link:config/co
 * *__OS_ORIGIN_BRANCH*: The branch you want to test. (*master* by default)
 * *__OS_PUBLIC_IP*: The IP of the VM. (*10.2.2.2* by default)
 * *__OS_APPS_DOMAIN*: Domain used by the applications (*apps.10.2.2.2.xip.io* by default)
-* *__OS_ACTION*: What do you want to do if doing a re-provisioning of the Box. (*none*, clean, build, config).
+* *__OS_ACTION*: What do you want to do if doing a re-provisioning of the Box. (*none*, clean, build, config, release).
+** *none*: normal behavior
 ** *clean*: Will delete the origin repo and the openshift install and pull down again the configured git repo, build origin, and configure it.
 ** *build*: Will delete the openshift install and update current origin repo from GitHub, build origin, and configure it.
 ** *config*: With the Origin instance you have built, just recreate the installation and configuration.
+** *release*: Will use a release published in github to install, and not building from source code
 * *__OS_CONFIG*: What do you want to do if doing a re-provisioning of the Box. ()
 ** *testusers*: Add addtional users (for test)
 ** *originimages*: Pull down origin images
@@ -89,12 +91,13 @@ For the installation (This configuration will be in the VM or in *link:config/co
 * *__OS_BUILD_IMAGES*: Whether to build Origin images as part of the build, or use latest publishes images (true|*false*). Building images takes a lot of time (>15 minutes).
 * *__OS_IMAGES_VERSION*: Version of images to use if not building them. Should be aligned with *__OS_ORIGIN_BRANCH* for Origin releases.
 * *__OS_JOURNAL_SIZE*: Size to provide to system journal (defaults: 100M). Use M,G to qualify the size.
+* *__OS_DOCKER_VERSION*: Version of docker package to be installed or empty string to install latest available version (default: ""). If using Openshift branch/release v1.3.0-alpha.2 or older then the docker version "1.9.1-25.el7.centos" must be installed.
 * *__OS_DOCKER_STORAGE_SIZE*: Size to provide for Docker filesystem. (defaults 30G). Use G to qualify size in Gigabytes.
 
 You can of course do it on creation time:
 
 ----
-echo "export __OS_ORIGIN_REPO=spadgett" > config/config.env 
+echo "export __OS_ORIGIN_REPO=spadgett" > config/config.env
 echo "export __ORIGIN_BRANCH=route-named-ports" >> config/config.env
 vagrant up
 ----
@@ -104,7 +107,7 @@ Or a later provisioning:
 ----
 vagrant ssh
 sudo -i
-echo "export __OS_ORIGIN_REPO=spadgett" > /config/config.env 
+echo "export __OS_ORIGIN_REPO=spadgett" > /config/config.env
 echo "export __OS_ORIGIN_BRANCH=route-named-ports" >> /config/config.env
 echo "export __OS_ACTION=clean" >> /config/config.env
 /scripts/install.sh

--- a/config/config-example.env
+++ b/config/config-example.env
@@ -4,5 +4,6 @@
 #
 export __OS_ACTION="release"
 export __OS_ORIGIN_BRANCH="v1.3.0-alpha.2"
-export __OS_CONFIG="xpaastemplates,metrics,testusers" 
+export __OS_DOCKER_VERSION="1.9.1-25.el7.centos"
+export __OS_CONFIG="xpaastemplates,metrics,testusers"
 export __OS_XPAAS_TAG="ose-v1.3.1"

--- a/config/config.env
+++ b/config/config.env
@@ -5,7 +5,7 @@ export __OS_PUBLIC_IP="10.2.2.2"
 export __OS_APPS_DOMAIN="apps.10.2.2.2.xip.io"
 
 # Action to be done if you execute the script /scripts/install.sh from within the VM.
-# Values: (none, clean, build, config) (default: none)
+# Values: (none, clean, build, config, release) (default: none)
 #   none: normal behavior
 #   clean: Will delete your current install and source, pull down a repository and install
 #   build: Will delete your current install, but not the source, so it will just rebuild
@@ -13,7 +13,7 @@ export __OS_APPS_DOMAIN="apps.10.2.2.2.xip.io"
 #   release: Will use a release published in github to install, and not building from source code
 export __OS_ACTION="none"
 
-# Repository name (default: openshift) to look for the origin clone. 
+# Repository name (default: openshift) to look for the origin clone.
 # Will look like this when composed: https://github.com/openshift/origin
 export __OS_ORIGIN_REPO="openshift"
 
@@ -26,6 +26,10 @@ export __OS_IMAGES_VERSION=latest
 # Should the building process also build the images? (default: false)
 export __OS_BUILD_IMAGES=false
 
+# Version of docker package to be installed or empty string to install latest available version (default: "").
+# If using Openshift branch/release v1.3.0-alpha.2 or older then the docker version "1.9.1-25.el7.centos" must be installed.
+export __OS_DOCKER_VERSION=""
+
 # Size reserved for docker filesystem. (default: 30G) (Use a number suffixed by G)
 export __OS_DOCKER_STORAGE_SIZE=30G
 
@@ -34,7 +38,7 @@ export __OS_JOURNAL_SIZE=100M
 
 # Additional capabilities that can be installed apart from origin
 # testusers,originimages,centosimages,rhelimages,xpaasimages,otherimages,xpaastemplates,osetemplates,metrics,logging
-export __OS_CONFIG="xpaastemplates,metrics,logging,testusers" 
+export __OS_CONFIG="xpaastemplates,metrics,logging,testusers"
 
 # Should a rerun force installation (default: false)
 export __OS_FORCE=false

--- a/scripts/base/docker-setup
+++ b/scripts/base/docker-setup
@@ -24,12 +24,12 @@ DOCKER-Setup(){
 
       ##  Enable the internal registry and configure the Docker to allow pushing to internal OpenShift registry
       echo "[INFO] Configuring Docker for Red Hat registry and else ..."
-      sed -i -e "s/^.*INSECURE_REGISTRY=.*/INSECURE_REGISTRY='--insecure-registry 0\.0\.0\.0\/0 '/" /etc/sysconfig/docker 
-      sed -i -e "s/^.*OPTIONS=.*/OPTIONS='--selinux-enabled --storage-opt dm\.no_warn_on_loop_devices=true --storage-opt dm\.loopdatasize=${__OS_DOCKER_STORAGE_SIZE}'/" /etc/sysconfig/docker
-      # sed -i -e "s/^.*ADD_REGISTRY=.*/ADD_REGISTRY='--add-registry registry\.access\.redhat\.com'/" /etc/sysconfig/docker 
+      sed -i -e "s/^.*INSECURE_REGISTRY=.*/INSECURE_REGISTRY='--insecure-registry 0\.0\.0\.0\/0 '/" /etc/sysconfig/docker
+      sed -i -e "s/^.*OPTIONS=.*/OPTIONS='--selinux-enabled --storage-opt dm\.loopdatasize=${__OS_DOCKER_STORAGE_SIZE}'/" /etc/sysconfig/docker
+      # sed -i -e "s/^.*ADD_REGISTRY=.*/ADD_REGISTRY='--add-registry registry\.access\.redhat\.com'/" /etc/sysconfig/docker
 
       ## Disable firewall
-      systemctl stop firewalld; systemctl disable firewalld 
+      systemctl stop firewalld; systemctl disable firewalld
       systemctl start docker; systemctl enable docker
 
       marker_create "docker.setup"

--- a/scripts/base/os-setup
+++ b/scripts/base/os-setup
@@ -17,14 +17,14 @@ OS-Setup(){
          # Enable go-lang 1.6 until official
          curl -skL https://copr.fedorainfracloud.org/coprs/jcajka/golang1.6/repo/epel-7/jcajka-golang1.6-epel-7.repo -o /etc/yum.repos.d/jcajka-golang1.6-epel-7.repo
          # Install additional packages
-         yum install -y docker-1.9.1-25.el7.centos git golang bind-utils bash-completion htop nfs-utils; yum clean all
+         yum install -y docker${__OS_DOCKER_VERSION:+-${__OS_DOCKER_VERSION}} git golang bind-utils bash-completion htop nfs-utils; yum clean all
          # TODO: Maybe update the whole box with: yum update
       else
          # Using fedora 23+
          # Enable go-lang 1.6 until official
          dnf copr -y enable jcajka/golang1.6
          # Install additional packages
-         dnf install -y docker git golang bind-utils bash-completion htop nfs-utils; dnf clean all
+         dnf install -y docker${__OS_DOCKER_VERSION:+-${__OS_DOCKER_VERSION}} git golang bind-utils bash-completion htop nfs-utils; dnf clean all
          # TODO: Maybe update the whole box with: dnf update
       fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,6 +41,7 @@ load_configuration
 : ${__OS_ORIGIN_BRANCH:="master"}
 : ${__OS_BUILD_IMAGES:="false"}
 : ${__OS_CONFIG:="xpaastemplates,metrics,logging"} # testusers,originimages,centosimages,rhelimages,xpaasimages,otherimages,osetemplates,xpaastemplates,metrics,logging
+: ${__OS_DOCKER_VERSION:=""}
 : ${__OS_DOCKER_STORAGE_SIZE:="30G"}
 : ${__OS_JOURNAL_SIZE:="100M"}
 : ${__OS_FORCE:=false}


### PR DESCRIPTION
Removed docker package version specification for Centos yum install to install latest version available. Currently latest version of docker is 1.10, which support schema version 2.