### PR TITLE
Add epel release repository required by htop package.

### DIFF
--- a/scripts/base/os-setup
+++ b/scripts/base/os-setup
@@ -16,6 +16,8 @@ OS-Setup(){
          # Using centos 7
          # Enable go-lang 1.6 until official
          curl -skL https://copr.fedorainfracloud.org/coprs/jcajka/golang1.6/repo/epel-7/jcajka-golang1.6-epel-7.repo -o /etc/yum.repos.d/jcajka-golang1.6-epel-7.repo
+         # Enable epel repository
+         yum install -y epel-release
          # Install additional packages
          yum install -y docker${__OS_DOCKER_VERSION:+-${__OS_DOCKER_VERSION}} git golang bind-utils bash-completion htop nfs-utils; yum clean all
          # TODO: Maybe update the whole box with: yum update


### PR DESCRIPTION
The `htop` package is not part of standard centos repositories. The `epel` repository must be add before installing `htop` package