### PR TITLE
Add filter for cross build only for listed platforms.

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -88,11 +88,16 @@ For the installation (This configuration will be in the VM or in *link:config/co
 * *__OS_FORCE_OS*
 * *__OS_FORCE_DOCKER*
 * *__OS_FORCE_ADDONS*
+* *__OS_ONLY_BUILD_PLATFORMS*: List of platforms to run cross builds or empty list to build for all (defaults: *linux/amd64*). Available platforms:
+** *linux/amd64*
+** *darwin/amd64*
+** *windows/amd64*
+** *linux/386*
 * *__OS_BUILD_IMAGES*: Whether to build Origin images as part of the build, or use latest publishes images (true|*false*). Building images takes a lot of time (>15 minutes).
 * *__OS_IMAGES_VERSION*: Version of images to use if not building them. Should be aligned with *__OS_ORIGIN_BRANCH* for Origin releases.
 * *__OS_JOURNAL_SIZE*: Size to provide to system journal (defaults: 100M). Use M,G to qualify the size.
 * *__OS_DOCKER_VERSION*: Version of docker package to be installed or empty string to install latest available version (default: ""). If using Openshift branch/release v1.3.0-alpha.2 or older then the docker version "1.9.1-25.el7.centos" must be installed.
-* *__OS_DOCKER_STORAGE_SIZE*: Size to provide for Docker filesystem. (defaults 30G). Use G to qualify size in Gigabytes.
+* *__OS_DOCKER_STORAGE_SIZE*: Size to provide for Docker filesystem. (defaults: 30G). Use G to qualify size in Gigabytes.
 
 You can of course do it on creation time:
 

--- a/config/config-example.env
+++ b/config/config-example.env
@@ -4,6 +4,7 @@
 #
 export __OS_ACTION="release"
 export __OS_ORIGIN_BRANCH="v1.3.0-alpha.2"
+export __OS_ONLY_BUILD_PLATFORMS="linux/amd64,darwin/amd64,windows/amd64,linux/386"
 export __OS_DOCKER_VERSION="1.9.1-25.el7.centos"
 export __OS_CONFIG="xpaastemplates,metrics,testusers"
 export __OS_XPAAS_TAG="ose-v1.3.1"

--- a/config/config.env
+++ b/config/config.env
@@ -23,6 +23,10 @@ export __OS_ORIGIN_BRANCH="master"
 # Version of the images to use (default: latest). If building a specific repository tag you should adjust the images
 export __OS_IMAGES_VERSION=latest
 
+# List of platforms to run cross builds or empty list to build for all.
+# Available platforms: linux/amd64,darwin/amd64,windows/amd64,linux/386
+export __OS_ONLY_BUILD_PLATFORMS="linux/amd64"
+
 # Should the building process also build the images? (default: false)
 export __OS_BUILD_IMAGES=false
 

--- a/scripts/base/origin-setup
+++ b/scripts/base/origin-setup
@@ -115,12 +115,12 @@ BUILD(){
   then
     # We build
     cd ${__BUILD_DIR}/origin
-    hack/build-go.sh
+    OS_ONLY_BUILD_PLATFORMS=${__OS_ONLY_BUILD_PLATFORMS-} hack/build-go.sh
     # TODO: Test this
     if [ "${__OS_BUILD_IMAGES}" = "true" ]
     then
       hack/build-base-images.sh
-      hack/build-release.sh
+      OS_ONLY_BUILD_PLATFORMS=${__OS_ONLY_BUILD_PLATFORMS-} hack/build-release.sh
       hack/build-images.sh
       export __VERSION=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null)
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,6 +39,7 @@ load_configuration
 : ${__OS_ACTION:="none"} # (none, clean, build, config)
 : ${__OS_ORIGIN_REPO:="openshift"}
 : ${__OS_ORIGIN_BRANCH:="master"}
+: ${__OS_ONLY_BUILD_PLATFORMS:="linux/amd64"}
 : ${__OS_BUILD_IMAGES:="false"}
 : ${__OS_CONFIG:="xpaastemplates,metrics,logging"} # testusers,originimages,centosimages,rhelimages,xpaasimages,otherimages,osetemplates,xpaastemplates,metrics,logging
 : ${__OS_DOCKER_VERSION:=""}


### PR DESCRIPTION
Added `__OS_ONLY_BUILD_PLATFORMS` configuration that controls for which platforms the cross build is started. 

Available platforms as per openshift/origin hack scripts currently are: 
- linux/amd64
- darwin/amd64
- windows/amd64
- linux/386.

As per default, only the `linux/amd64` binaries are build to speed up the provisioning.